### PR TITLE
Cast types based on database driver

### DIFF
--- a/src/Cast.php
+++ b/src/Cast.php
@@ -1,8 +1,8 @@
 <?php
 namespace ProcessMaker\Query;
 
-use Exception;
 use Illuminate\Support\Facades\DB;
+use ProcessMaker\Query\SyntaxError;
 
 class Cast extends BaseField
 {
@@ -65,7 +65,7 @@ class Cast extends BaseField
         }
 
         $types = implode(', ', $this->getSupportedTypes());
-        throw new Exception("Unsupported cast type. Casts must be of type: {$types}.");
+        throw new SyntaxError("Unsupported cast type. Casts must be of type: {$types}.", $this->getSupportedTypes(), $type, 0, 0, 0);
     }
 
     public function toEloquent($connection = null)

--- a/src/Cast.php
+++ b/src/Cast.php
@@ -1,17 +1,30 @@
 <?php
 namespace ProcessMaker\Query;
 
+use Exception;
 use Illuminate\Support\Facades\DB;
 
 class Cast extends BaseField
 {
     protected $field;
+
     protected $type;
+    
+    protected $types = [
+        'number' => [
+            'mysql' => 'decimal',
+            'sqlite' => 'integer',
+        ],
+        'text' => [
+            'mysql' => 'char',
+            'sqlite' => 'text',
+        ],
+    ];
 
     public function __construct($field, $type)
     {
         $this->field = $field;
-        $this->type = $type;
+        $this->type = $this->mapType($type);
     }
 
     public function toArray()
@@ -22,6 +35,37 @@ class Cast extends BaseField
                 'type' => $this->type
             ]
         ];
+    }
+    
+    private function getConnectionDriver()
+    {
+        $config = DB::connection()->getConfig();
+        return $config['driver'];
+    }
+    
+    private function getSupportedTypes()
+    {
+        $list = [];
+        
+        foreach ($this->types as $key => $value) {
+            $list[] = $key;
+        }
+        
+        return $list;
+    }
+    
+    private function mapType($type)
+    {
+        $driver = $this->getConnectionDriver();
+        
+        if (array_key_exists($type, $this->types)) {
+            if (array_key_exists($driver, $this->types[$type])) {
+                return $this->types[$type][$driver];
+            }
+        }
+
+        $types = implode(', ', $this->getSupportedTypes());
+        throw new Exception("Unsupported cast type. Casts must be of type: {$types}.");
     }
 
     public function toEloquent($connection = null)

--- a/tests/Feature/GrammarTest.php
+++ b/tests/Feature/GrammarTest.php
@@ -309,7 +309,7 @@ class GrammarTest extends TestCase
     public function testQueryWithCast()
     {
         $parser = new Parser();
-        $tree = $parser->parse('cast(data.age as integer) > 25');
+        $tree = $parser->parse('cast(data.age as number) > 25');
         $this->assertEquals([
             'logical' => 'AND',
             'expressions' => [

--- a/tests/Feature/GrammarTest.php
+++ b/tests/Feature/GrammarTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace ProcessMaker\Query\Tests\Feature;
 
+use Exception;
 use ProcessMaker\Query\Parser;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\Query\Tests\TestCase;
@@ -330,6 +331,13 @@ class GrammarTest extends TestCase
                 ],
             ],
         ], $tree->toArray());
-
+    }
+    
+    public function testQueryWithUnsupportedCastType()
+    {
+        $this->expectException(Exception::class);
+        
+        $parser = new Parser();
+        $tree = $parser->parse('cast(data.age as integer) > 25');
     }
 }

--- a/tests/Feature/GrammarTest.php
+++ b/tests/Feature/GrammarTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace ProcessMaker\Query\Tests\Feature;
 
-use Exception;
 use ProcessMaker\Query\Parser;
 use ProcessMaker\Query\SyntaxError;
 use ProcessMaker\Query\Tests\TestCase;
@@ -335,7 +334,7 @@ class GrammarTest extends TestCase
     
     public function testQueryWithUnsupportedCastType()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(SyntaxError::class);
         
         $parser = new Parser();
         $tree = $parser->parse('cast(data.age as integer) > 25');

--- a/tests/Feature/TraitTest.php
+++ b/tests/Feature/TraitTest.php
@@ -81,12 +81,12 @@ class TraitTest extends TestCase
 
     public function testQueryWithCast()
     {
-        $results = TestRecord::pmql('cast(data.age as integer) > 40')->get();
+        $results = TestRecord::pmql('cast(data.age as number) > 40')->get();
         $this->assertCount(0, $results);
-        $results = TestRecord::pmql('cast(data.age as integer) < 40')->get();
+        $results = TestRecord::pmql('cast(data.age as number) < 40')->get();
         // Should retrieve all of our records
         $this->assertCount(5, $results);
-        $results = TestRecord::pmql('cast(data.age as integer) < 35')->get();
+        $results = TestRecord::pmql('cast(data.age as number) < 35')->get();
         $this->assertCount(2, $results);
 
     }


### PR DESCRIPTION
## Changes
- Converts types used in the cast function based on database driver
- Throws a **SyntaxError** if an unsupported type is specified

## Notes
- Supported drivers are: MySQL, SQLite
- Converts **number** to decimal (MySQL) or integer (SQLite)
- Converts **text** to char (MySQL) or text (SQLite)

Closes #3.