### PR TITLE
Support Laravel 5.7+ and Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         }
     },
     "require": {
-        "laravel/framework": "~5.7.0|~5.8.0"
+        "laravel/framework": "^5.7|^6"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.5",
-        "phpunit/phpunit": "^7.0"
+        "orchestra/testbench": "^4.8.0",
+        "phpunit/phpunit": "^8.3"
     }
 }


### PR DESCRIPTION
## Changes
- Update composer.json to support Laravel 5.7+ and any version of Laravel 6

## Notes
- Once this is merged and published, [ProcessMaker](https://github.com/ProcessMaker/processmaker) will need to be updated to support it

Part of https://processmaker.atlassian.net/browse/FOUR-2516