### PR TITLE
Bugfix/Four-4970: PMQL not working when comparing less or more than values (For 4.2)

### DIFF
--- a/grammar/pmql.pegjs
+++ b/grammar/pmql.pegjs
@@ -1,7 +1,7 @@
 /**
-* This ProcessMaker Query Language Grammar is based off of a subset 
-* of SQL. Column names and values are validated by a callback passed in through 
-* the options variable or is passed-thru. A laravel eloquent query object is 
+* This ProcessMaker Query Language Grammar is based off of a subset
+* of SQL. Column names and values are validated by a callback passed in through
+* the options variable or is passed-thru. A laravel eloquent query object is
 * also passed through as the starting point.
 * The query language only provides the where clause of a SQL statement.
 * The ordering and limiting is meant to be handled by the PMQL caller.
@@ -20,7 +20,7 @@
 
 start  = fullExpression
 
-fullExpression = le:logicExpression ler:logicExpressionRest* { 
+fullExpression = le:logicExpression ler:logicExpressionRest* {
   $collection = new \ProcessMaker\Query\ExpressionCollection();
   // Add to our collection
   if($le) {
@@ -49,7 +49,7 @@ logicExpressionRest = go:group_operator _ le:logicExpression {
 }
 
 field =
-  v: ( whitespace ( 
+  v: ( whitespace (
     (
       "CAST"i lparen field:field _ "AS"i _ type:name rparen { return new \ProcessMaker\Query\Cast($field, $type); }
     )
@@ -63,7 +63,7 @@ field =
     column_name
   ) ) { return $v[1]; }
 
-function_args = 
+function_args =
   x:(( value / field / interval_expr) (tail:(_ "," _ (value / field / interval_expr)) {return $tail[3];})*) {
     $params = [];
     if(isset($x[0]) && !empty($x[0])) {
@@ -76,13 +76,13 @@ function_args =
   }
   /
   _ {return [];}
-  
+
 interval_expr =
  x: ('NOW'i whitespace ('-' / '+') number whitespace interval_type) { $value = floatval($x[2] . $x[3]); return new \ProcessMaker\Query\IntervalExpression($value, $x[5]); }
  /
  'NOW'i {return new \ProcessMaker\Query\IntervalExpression();}
 
-interval_type = 
+interval_type =
   x: (DAY / HOUR / MINUTE / SECOND) { return strtoupper($x); }
 
 
@@ -98,16 +98,16 @@ SECOND = "SECOND"i
 * Currently what values we support. Right now we only support literals
 */
 value =
-  v: ( whitespace ( 
+  v: ( whitespace (
     interval_expr
     /
-    ( 
-      x: literal_value { return new \ProcessMaker\Query\LiteralValue($x) ; } 
+    (
+      x: literal_value { return new \ProcessMaker\Query\LiteralValue($x) ; }
     )
   ) ) { return $v[1]; }
 
 array_value =
-  v: ( whitespace ( 
+  v: ( whitespace (
       x: bracketed_values { return new \ProcessMaker\Query\ArrayValue($x); }
   ) ) { return $v[1]; }
 
@@ -122,7 +122,7 @@ literal_value =
 
 bracketed_values =
   lbrack _ comma_separated_literals+ _ rbrack
-  
+
 
 comma_separated_literals = literal_value ',' _ comma_separated_literals / literal_value
 
@@ -130,10 +130,14 @@ comma_separated_literals = literal_value ',' _ comma_separated_literals / litera
 * Number related rules
 * Blatently taken from the number rule at https://github.com/pegjs/pegjs/blob/master/examples/json.pegjs
 */
-number = str:(minus? int frac? exp?) { 
-  return floatval(\ProcessMaker\Query\Processor::flatstr(
-      \ProcessMaker\Query\Processor::flatten($str, true), true
-  )); 
+number = str:(minus? int frac? exp?) {
+  $flatted = \ProcessMaker\Query\Processor::flatstr(
+    \ProcessMaker\Query\Processor::flatten($str, true), true
+  );
+  if(strpos($flatted, ".")) {
+    return floatval($flatted);
+  }
+  return intval($flatted);
 }
 int = zero / (digit1_9 digit *)
 frac = dot digit+

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -63,10 +63,6 @@ if (!class_exists("ProcessMaker\Query\\SyntaxError", false)) {
     }
 }
 
-function isFloat($val) {
-    return strpos($val, ".");
-}
-
 class Parser {
     private $peg_currPos          = 0;
     private $peg_reportedPos      = 0;
@@ -383,11 +379,13 @@ class Parser {
     private function peg_f15($dn) { return new \ProcessMaker\Query\JsonField(\ProcessMaker\Query\Processor::flatstr($dn, true)); }
     private function peg_f16($el) { return \ProcessMaker\Query\Processor::flatstr($el, true); }
     private function peg_f17($ae) { return \ProcessMaker\Query\Processor::flatstr($ae); }
-    private function peg_f18($val) {
+    private function peg_f18($str) {
       $flatted = \ProcessMaker\Query\Processor::flatstr(
-        \ProcessMaker\Query\Processor::flatten($val, true), true
+        \ProcessMaker\Query\Processor::flatten($str, true), true
       );
-      if(isFloat($flatted)) return floatval($flatted);
+      if(strpos($flatted, ".")) {
+        return floatval($flatted);
+      }
       return intval($flatted);
     }
     private function peg_f19($str) { return \ProcessMaker\Query\Processor::flatstr($str[1]); }

--- a/tests/Feature/NumberCastingTest.php
+++ b/tests/Feature/NumberCastingTest.php
@@ -5,7 +5,7 @@ namespace ProcessMaker\Query\Tests\Feature;
 use ProcessMaker\Query\Parser;
 use ProcessMaker\Query\Tests\TestCase;
 
-class Peg_f18Test extends TestCase
+class NumberCastingTest extends TestCase
 {
     /**
      * Tests a returning a float when passing a string float value


### PR DESCRIPTION
## Issue & Reproduction Steps
PDO doesn't have a type float for binding params, so float numbers are treated as string (PDO::PARAM_STR). When using less than operator for example, the comparison is like a string so if we compare if 100 < 80 the result will be true.

When passing an integer, e.g. 80, parsing function was converting this integer to a float value (80.0) and using it with less than operator was causing the issue. So to fix that, when integer is passed to parser now, parser will return an integer (80) and the less than operator will work as it should work. But according with the PDO limitation, when passing a float number it will be treated as string.

Reproduction steps
- Import the process (see attached file)
- Start 4 requests and put the data 9, 30, 39, 35 for the input2 
- Search by custom PMQL `(request = "Regression 4.1.25 Requests") AND (data.input2 >= 5)`
- You will see only one record and should be 4 records for the search 9, 30, 35 and 39

## Solution
- Check if value are float or integer on pmql.pegjs to generate correct parser file

**IMPORTANT:**
**Please regenerate the Parser.php file:** 
- Run `npm install` in PMQL package
- Run `npm run build`. The Parse.php file will be regenerated with the correct code.

## How to Test
- Import the process (see attached file)
- Start 4 requests and put the data 9, 30, 39, 35 for the input2 
- Search by custom PMQL `(request = "Regression 4.1.25 Requests") AND (data.input2 >= 5)`
- You should see 4 records for the search 9, 30, 35 and 39
- NOTE: you can test with different searches using the operators >, <, >=, <= and different values

Run test cases under tests/Feature/NumberCastingTest.php

**Working video**

https://user-images.githubusercontent.com/90727999/149979268-79243fbf-fda6-443c-bc5b-d68b37272207.mov


## Related Tickets & Packages
- [FOUR-4970](https://processmaker.atlassian.net/browse/FOUR-4970)


