### PR TITLE
IN and NOT IN Operators for Array Values not working

### DIFF
--- a/src/ArrayValue.php
+++ b/src/ArrayValue.php
@@ -6,14 +6,18 @@ class ArrayValue extends BaseValue
 {
     public function value()
     {
-        $list = $this->value[2];
-        if (is_array($list[0])) {
-            $result = $this->extractValue($list[0]);
-        } else {
-            $result = $list;
-        }
+        if (is_array($this->value) && $this->value[0] === "[") {
+            $list = $this->value[2];
+            if (is_array($list[0])) {
+                $result = $this->extractValue($list[0]);
+            } else {
+                $result = $list;
+            }
 
-        return $result;
+            return $result;
+        } else {
+            return $this->value;
+        }
     }
 
     private function extractValue($chunk, &$values = [])


### PR DESCRIPTION
## Issue & Reproduction Steps
Perform a PMQL search query with (IN or NOT IN)

**Current behavior**
when the search is done not return results and returns a server error.

**Expected behavior**
The search with PMQL (IN, NOT IN) should work fine and not returns a server error.

## Solution
- Add validation in the structure of ArrayValue.

**Working video**


https://user-images.githubusercontent.com/1747025/193937549-deab4ec4-12ca-4514-a622-b372adb69eb2.mp4



## How to Test
perform PMQL queries on the section to fetch

## Related Tickets & Packages
- [FOUR-6782](https://processmaker.atlassian.net/browse/FOUR-6782)
