### PR TITLE
FOUR-12716: PMQL "lower" function is not working correctly

### DIFF
--- a/src/Exceptions/UnsupportedQueryGrammarException.php
+++ b/src/Exceptions/UnsupportedQueryGrammarException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ProcessMaker\Query\Exceptions;
+
+use Exception;
+
+class UnsupportedQueryGrammarException extends Exception
+{
+    public function __construct(
+        $message = 'Unsupported query grammar for handling JSON fields.',
+        $code = 0,
+        Exception $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/FunctionCall.php
+++ b/src/FunctionCall.php
@@ -35,7 +35,13 @@ class FunctionCall extends BaseField
     {
         $params = [];
         foreach ($this->params as $param) {
-            $params[] = $param->toEloquent();
+            $eloquentParam = $param->toEloquent();
+            if (is_object($eloquentParam)) {
+                $grammar = DB::connection()->getQueryGrammar();
+                $eloquentParam = $eloquentParam->getValue($grammar);
+            }
+
+            $params[] = $eloquentParam;
         }
 
         return $this->name . '(' . implode(',', $params) . ')';

--- a/src/JsonField.php
+++ b/src/JsonField.php
@@ -25,9 +25,7 @@ class JsonField extends BaseField
         // Convert to Laravel Database Json Syntax
         $value = str_replace('.', '->', $this->field);
         if (is_a($grammar, MySqlGrammar::class)) {
-            return $connection
-                ->raw((new \ProcessMaker\Query\Grammars\MySqlGrammar)->wrapJsonSelector($value))
-                ->getValue($grammar);
+            return $connection->raw((new \ProcessMaker\Query\Grammars\MySqlGrammar)->wrapJsonSelector($value));
         } elseif (is_a($grammar, SQLiteGrammar::class)) {
             return $connection->raw((new \ProcessMaker\Query\Grammars\SQLiteGrammar)->wrapJsonSelector($value));
         } else {

--- a/src/JsonField.php
+++ b/src/JsonField.php
@@ -2,10 +2,10 @@
 
 namespace ProcessMaker\Query;
 
-use Exception;
 use Illuminate\Database\Query\Grammars\MySqlGrammar;
 use Illuminate\Database\Query\Grammars\SQLiteGrammar;
 use Illuminate\Support\Facades\DB;
+use ProcessMaker\Query\Exceptions\UnsupportedQueryGrammarException;
 
 class JsonField extends BaseField
 {
@@ -25,11 +25,13 @@ class JsonField extends BaseField
         // Convert to Laravel Database Json Syntax
         $value = str_replace('.', '->', $this->field);
         if (is_a($grammar, MySqlGrammar::class)) {
-            return $connection->raw((new \ProcessMaker\Query\Grammars\MySqlGrammar)->wrapJsonSelector($value));
+            return $connection
+                ->raw((new \ProcessMaker\Query\Grammars\MySqlGrammar)->wrapJsonSelector($value))
+                ->getValue($grammar);
         } elseif (is_a($grammar, SQLiteGrammar::class)) {
             return $connection->raw((new \ProcessMaker\Query\Grammars\SQLiteGrammar)->wrapJsonSelector($value));
         } else {
-            throw new Exception('Unsupported query grammar for handling JSON fields.');
+            throw new UnsupportedQueryGrammarException();
         }
     }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR is part of: https://github.com/ProcessMaker/processmaker/pull/5779

## Solution

In Laravel 8, the Expression class included the magic method __toString(), which allowed direct access to its value. However, this method was removed in Laravel 10. Now, to obtain the value of an Expression object, it is necessary to use the getValue($grammar) method. This change ensures that a string is returned instead of the Expression object.

## How to Test
Run `php artisan test --filter ExtendedPMQLTest::testLowerFunction`.

## Related Tickets & Packages
- [FOUR-12716](https://processmaker.atlassian.net/browse/FOUR-12716)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/5779)

[FOUR-12716]: https://processmaker.atlassian.net/browse/FOUR-12716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ